### PR TITLE
「戦い」ではなく「戰い」である

### DIFF
--- a/sun.cgi
+++ b/sun.cgi
@@ -128,6 +128,7 @@ class NotSubculture(object):
            u'(doge2048|JAL\s?123)': u'なるほど',
            u'(鐵|鐡)道(では)?$': u'おっ',
            u'電車': u'鐵道または軌道車',
+           u'戦い': u'戰いでしょ',
            u'拝承': u'拝復',
            u'^おもち$': SubcultureOmochi,
            u'山だ?$': u'やまいくぞ',


### PR DESCRIPTION
```
[11/19/14, 7:42:43 PM] takano32: ディラックの海のところと、男の戦いのところが好きなんだよなー
[11/19/14, 7:43:27 PM] ykic: 高野さん
[11/19/14, 7:43:40 PM] ykic: 「男の戰い」です。
[11/19/14, 7:43:46 PM] esehara: 訂正だ
[11/19/14, 7:44:06 PM] takano32: はい。 ATOK ゴミですね。
[11/19/14, 7:44:17 PM] takano32: でない。闘いと戦いのみ
[11/19/14, 7:44:23 PM] ykic: それはゴミですね。
[11/19/14, 7:44:34 PM] ykic: 「たたかい」で変換できなくても「おとこのたたかい」で変換できるべき
[11/19/14, 7:44:44 PM] ykic: エヴァのサブタイトルくらい全て変換してほしいものです。
[11/19/14, 7:44:55 PM] ykic: 基礎教養だし、常用語である。
[11/19/14, 7:45:33 PM] VoQn: subに教えよう
[11/19/14, 7:45:57 PM] esehara: メイン機能増えすぎでは
[11/19/14, 7:46:21 PM] VoQn: 戰い
```
