### PR TITLE
Python環境をシステムと分離する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	find . -name "*.py[co]" -delete
 
 setup:
-	virtualenv . --system-site-packages
+	virtualenv .
 	./bin/pip install -r requirements.txt
 
 status:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flake8==2.2.5
 redis==2.10.3
 requests==2.5.0
 wsgiref==0.1.2
+https://mecab.googlecode.com/files/mecab-python-0.996.tar.gz
+

--- a/script/devserver_provisioning.sh
+++ b/script/devserver_provisioning.sh
@@ -1,10 +1,11 @@
 sudo apt-get update -y
 
 sudo apt-get install python -y
+sudo apt-get install python-dev -y
 sudo apt-get install python-pip -y
 sudo apt-get install python-virtualenv -y
 sudo apt-get install mecab-ipadic-utf8 -y
-sudo apt-get install python-mecab -y
+sudo apt-get install libmecab-dev -y
 sudo apt-get install redis-server -y
 
 


### PR DESCRIPTION
```
virtualenv .  --system-site-packages
```

をやめる。

virtualenv環境へはpipでpython-mecabをインストールする。
これでtravisでのテストやherokuへのデプロイが可能になるはず。
