### PR TITLE
Fix replay gif image to 止まらないんすよ

### DIFF
--- a/sun.py
+++ b/sun.py
@@ -1275,7 +1275,7 @@ class NotSubculture(object):
         # u'(Mac|マック|OSX|osx)': u'マックパワー/aB',
         u'^弁当$': u'便當だろ',
         u'\bシュッ\b': u'シュッ！シュッ！\nんっ ...',
-        # u'(止|と)ま(ら|ん)ない(んす|んすよ)?': u'http://33.media.tumblr.com/4ad95c7221816073ea18a4ff7b7040c3/tumblr_nf7906ogQV1qzxg8bo1_400.gif',
+        u'(止|と)ま(ら|ん)ない(んす|んすよ)?': u'https://i.gyazo.com/e50a1e1b5dd2a5cdd5c388f654bcf8a4.gif',
         u'^((ヤバ|やば)(イ|い)|yabai)$': u'WHOOP! WHOOP! PULL UP!!!/aA',
         '.+': SubcultureHitozuma,
         '..+': SubcultureKCzuma,


### PR DESCRIPTION
## About

- Currently, feature of replay gif image to 止まらないんすよ has been broken
- This pull request fix that feature


## Why and How

- Line 1278 of `sun.py` has been commented out because Tumblr has been removed this very important image
- I have uploaded this very important image to Gyazo, so replace URL of image and remove comment out the line 1278 of `sun.py`